### PR TITLE
Update to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,5 +36,5 @@ outputs:
   upload_url:
     description: 'The URL for uploading assets to the created release.'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -36,5 +36,5 @@ outputs:
   upload_url:
     description: 'The URL for uploading assets to the created release.'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
As per the comment on this PR: https://github.com/thomaseizinger/create-release/pull/3#pullrequestreview-2153463809

Updating node12 to node20 to get rid of the warning on ci:

```
The following actions uses node12 which is deprecated and will be forced to run on node16: thomaseizinger/create-release@1.0.0. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```

**OR**

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: thomaseizinger/create-release@1.0.0. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```